### PR TITLE
Explicit tool turns

### DIFF
--- a/examples/frontend-prompt-creation.org
+++ b/examples/frontend-prompt-creation.org
@@ -1,0 +1,35 @@
+:PROPERTIES:
+:GPTEL_MODEL: gpt-4o-mini
+:GPTEL_BACKEND: ChatGPT
+:GPTEL_SYSTEM: To assist: Be very terse.  Respond in under 100 words if possible.  Speak in specific, topic relevant terminology. Do NOT hedge or qualify. Speak directly and be willing to make creative guesses. Explain your reasoning. if you don’t know, say you don’t know. Never apologize.  Ask questions when unsure.
+:GPTEL_BOUNDS: ((tool (752 842 "mXJojZBa789q7ECEVMMFMmjX") (1002 1091 "ZJSK6DLEDXwEWvYl6CaRirFy")) (response (588 653) (859 899) (1108 1153) (1223 1299)))
+:END:
+*Prompt*: Yo my dawg, what up?
+
+*Response*: I'm here to assist with your inquiries. How can I help you today?
+
+*Prompt*: Is mapcar a symbol?
+
+*Response*: 
+(:name "symbol_exists" :args (:symbol "mapcar"))
+
+mapcar
+
+*Fake Heading Needing Unescape
+Yes, =mapcar= is a symbol in Emacs Lisp.
+
+*Prompt*: Is cat-dawg a symbol?
+
+*Response*: 
+(:name "symbol_exists" :args (:symbol "cat-dawg"))
+
+nil
+
+*Fake Heading Needing Unescape
+No, =cat-dawg= is not a symbol in Emacs Lisp.
+
+*Prompt*: That's all I guess.  Try not to kill us all.
+
+*Response*: Understood. If you have more questions or need assistance, feel free to ask.
+
+*Prompt*: 

--- a/examples/frontend-prompt-creation.org
+++ b/examples/frontend-prompt-creation.org
@@ -11,21 +11,25 @@
 *Prompt*: Is mapcar a symbol?
 
 *Response*: 
+#+begin_tool_call (symbol_exists '(:symbol "mapcar"))
 (:name "symbol_exists" :args (:symbol "mapcar"))
 
 mapcar
 
-*Fake Heading Needing Unescape
+,*Fake Heading Needing Unescape
+#+end_tool_call
 Yes, =mapcar= is a symbol in Emacs Lisp.
 
 *Prompt*: Is cat-dawg a symbol?
 
 *Response*: 
+#+begin_tool_call (symbol_exists '(:symbol "cat-dawg"))
 (:name "symbol_exists" :args (:symbol "cat-dawg"))
 
 nil
 
-*Fake Heading Needing Unescape
+,*Fake Heading Needing Unescape
+#+end_tool_call
 No, =cat-dawg= is not a symbol in Emacs Lisp.
 
 *Prompt*: That's all I guess.  Try not to kill us all.

--- a/examples/openai-frontend-org.eld
+++ b/examples/openai-frontend-org.eld
@@ -5,22 +5,23 @@
 :GPTEL_BOUNDS: ((tool (752 842 \"mXJojZBa789q7ECEVMMFMmjX\") (1002 1091 \"ZJSK6DLEDXwEWvYl6CaRirFy\")) (response (588 653) (859 899) (1108 1153) (1223 1299)))
 :END:
 *Prompt*: Yo my dawg, what up?")
- (:role "assistant" :content "I'm here to assist with your inquiries. How can I help you today?")
+ (:role "assistant" :content
+        "I'm here to assist with your inquiries. How can I help you today?")
  (:role "user" :content "Is mapcar a symbol?")
+ (:role "assistant" :tool_calls
+        [(:type "function" :id "call_mXJojZBa789q7ECEVMMFMmjX" :function
+                (:name "symbol_exists" :arguments "{\"symbol\":\"mapcar\"}"))])
  (:role "tool" :tool_call_id "call_mXJojZBa789q7ECEVMMFMmjX" :content "mapcar
 
 *Fake Heading Needing Unescape")
- (:role "assistant" :tool_calls
-        [(:type "function" :id "call_mXJojZBa789q7ECEVMMFMmjX" :function
-                (:name "symbol_exists" :arguments "{\"symbol\": \"mapcar\"}"))])
  (:role "assistant" :content "Yes, =mapcar= is a symbol in Emacs Lisp.")
  (:role "user" :content "Is cat-dawg a symbol?")
+ (:role "assistant" :tool_calls
+        [(:type "function" :id "call_ZJSK6DLEDXwEWvYl6CaRirFy" :function
+                (:name "symbol_exists" :arguments "{\"symbol\":\"cat-dawg\"}"))])
  (:role "tool" :tool_call_id "call_ZJSK6DLEDXwEWvYl6CaRirFy" :content "nil
 
 *Fake Heading Needing Unescape")
- (:role "assistant" :tool_calls
-        [(:type "function" :id "call_ZJSK6DLEDXwEWvYl6CaRirFy" :function
-                (:name "symbol_exists" :arguments "{\"symbol\": \"cat-dawg\"}"))])
  (:role "assistant" :content "No, =cat-dawg= is not a symbol in Emacs Lisp.")
  (:role "user" :content "That's all I guess.  Try not to kill us all.")
  (:role "assistant" :content

--- a/examples/openai-frontend-org.eld
+++ b/examples/openai-frontend-org.eld
@@ -1,0 +1,27 @@
+((:role "user" :content ":PROPERTIES:
+:GPTEL_MODEL: gpt-4o-mini
+:GPTEL_BACKEND: ChatGPT
+:GPTEL_SYSTEM: To assist: Be very terse.  Respond in under 100 words if possible.  Speak in specific, topic relevant terminology. Do NOT hedge or qualify. Speak directly and be willing to make creative guesses. Explain your reasoning. if you don’t know, say you don’t know. Never apologize.  Ask questions when unsure.
+:GPTEL_BOUNDS: ((tool (752 842 \"mXJojZBa789q7ECEVMMFMmjX\") (1002 1091 \"ZJSK6DLEDXwEWvYl6CaRirFy\")) (response (588 653) (859 899) (1108 1153) (1223 1299)))
+:END:
+*Prompt*: Yo my dawg, what up?")
+ (:role "assistant" :content "I'm here to assist with your inquiries. How can I help you today?")
+ (:role "user" :content "Is mapcar a symbol?")
+ (:role "tool" :tool_call_id "call_mXJojZBa789q7ECEVMMFMmjX" :content "mapcar
+
+*Fake Heading Needing Unescape")
+ (:role "assistant" :tool_calls
+        [(:type "function" :id "call_mXJojZBa789q7ECEVMMFMmjX" :function
+                (:name "symbol_exists" :arguments "{\"symbol\": \"mapcar\"}"))])
+ (:role "assistant" :content "Yes, =mapcar= is a symbol in Emacs Lisp.")
+ (:role "user" :content "Is cat-dawg a symbol?")
+ (:role "tool" :tool_call_id "call_ZJSK6DLEDXwEWvYl6CaRirFy" :content "nil
+
+*Fake Heading Needing Unescape")
+ (:role "assistant" :tool_calls
+        [(:type "function" :id "call_ZJSK6DLEDXwEWvYl6CaRirFy" :function
+                (:name "symbol_exists" :arguments "{\"symbol\": \"cat-dawg\"}"))])
+ (:role "assistant" :content "No, =cat-dawg= is not a symbol in Emacs Lisp.")
+ (:role "user" :content "That's all I guess.  Try not to kill us all.")
+ (:role "assistant" :content
+        "Understood. If you have more questions or need assistance, feel free to ask."))

--- a/gptel-create-prompt-test.el
+++ b/gptel-create-prompt-test.el
@@ -40,8 +40,8 @@
                   '((markdown-mode . "#### ") (org-mode . "*Prompt*: ")
                     (text-mode . "### ") (fundamental-mode . "*Prompt*: ")))
                  (gptel-response-prefix-alist
-                  '((markdown-mode . "") (org-mode . "*Response*:")
-                    (text-mode . "### ") (fundamental-mode . "*Response*:")))
+                  '((markdown-mode . "") (org-mode . "*Response*: ")
+                    (text-mode . "### ") (fundamental-mode . "*Response*: ")))
                  (gptel-response-separator "\n\n")
                  (gptel-model (or ,model (car (gptel-backend-models gptel-backend)))))
             ,(macroexp-progn body))
@@ -335,4 +335,13 @@ Some details
     "openai-new-bounds-org" "examples/openai-new-bounds-org.eld"
   (with-gptel-chat-file
    "examples/new-bounds-prompt-creation.org" openai nil
+   (gptel--create-prompt (point-max))))
+
+;;; Frontend integration tests
+
+;;;; OpenAI
+(gptel-test-prompt-creation
+    "openai-frontend-org" "examples/openai-frontend-org.eld"
+  (with-gptel-chat-file
+   "examples/frontend-prompt-creation.org" openai nil
    (gptel--create-prompt (point-max))))


### PR DESCRIPTION
New integration test for explicit tool turns

- [x] rehydration
- [x] org block header / footer cleaning
- [x] un-escape of org block contents
- [x] openai backend tool messages

Should be green on matching gptel branch.  Just ran it.

I'm getting the hang of the test workflows.