### PR TITLE
gemini: Update `gptel-test-tools-gemini` to use `:functionDeclarations`

### DIFF
--- a/gptel-parse-tool-spec.el
+++ b/gptel-parse-tool-spec.el
@@ -346,7 +346,7 @@ South and West (resp) are negative."
      :required ["name" "switch" "validateName"]))])
 
 (defvar gptel-test-tools-gemini
-  [(:function_declarations
+  [(:functionDeclarations
     [(:name "read_url" :description "Fetch and read the contents of a URL"
       :parameters
       (:type "object" :properties


### PR DESCRIPTION
Update tool declarations tests for Gemini to reflect the changes in https://github.com/karthink/gptel/pull/1202