### PR TITLE
Makefile: Improve compatibility and simplify

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 .PHONY: test
 test:
 	emacs -Q -L .. -L . \
-	$$(find .. -mindepth 1 -maxdepth 1 \( -name '.*.el' -prune -o -name '*.el' -type f -printf ' -l %p' \)) \
-	$$(find .  -mindepth 1 -maxdepth 1 \( -name '.*.el' -prune -o -name '*.el' -type f -printf ' -l %p' \)) \
+        $$(find .. -mindepth 1 -maxdepth 2 -name "gptel-*.el" -exec echo "-l {} \\"  \;) \
 	-l ert --batch -f ert-run-tests-batch-and-exit

--- a/README.org
+++ b/README.org
@@ -4,14 +4,9 @@ To run this suite, load all gptel elisp files, then all the elisp at the root of
 
 I populate this repo as a gptel submodule in the directory =test=, then run =make= from gptel's directory:
 
-#+begin_src makefile
-.PHONY: test
-test:
-	git submodule update --init --recursive
-	cd test && emacs -Q -L .. -L . \
-	$$(find .. -mindepth 1 -maxdepth 1 \( -name '.*.el' -prune -o -name '*.el' -type f -printf ' -l %p' \)) \
-	$$(find .  -mindepth 1 -maxdepth 1 \( -name '.*.el' -prune -o -name '*.el' -type f -printf ' -l %p' \)) \
-	-l ert --batch -f ert-run-tests-batch-and-exit
+#+begin_src shell
+  git submodule update --init --recursive
+  cd test && make
 #+end_src
 
 Modify as appropriate.


### PR DESCRIPTION
Drop using `-printf' which a non-POSIX GNU extension, so currently the Makefile does not work on e.g. macOS or FreeBSD.
