### PR TITLE
Add Bedrock multi-turn tool use parsing test

### DIFF
--- a/examples/bedrock-prompt-tool-block-org.eld
+++ b/examples/bedrock-prompt-tool-block-org.eld
@@ -1,0 +1,11 @@
+((:role "user" :content [(:text ":PROPERTIES:
+:GPTEL_MODEL: gpt-4o-mini
+:GPTEL_BACKEND: ChatGPT
+:GPTEL_SYSTEM: To assist: Be very terse.  Respond in under 100 words if possible.  Speak in specific, topic relevant terminology. Do NOT hedge or qualify. Speak directly and be willing to make creative guesses. Explain your reasoning. if you don’t know, say you don’t know. Never apologize.  Ask questions when unsure.
+:GPTEL_BOUNDS: ((tool (745 835 \"mXJojZBa789q7ECEVMMFMmjX\") (984 1078 \"ZJSK6DLEDXwEWvYl6CaRirFy\")) (response (587 652) (847 887) (1090 1135) (1205 1281)))
+:END:
+*Prompt*: Yo my dawg, what up?")]) (:role "assistant" :content [(:text "I'm here to assist with your inquiries. How can I help you today?")]) (:role "user" :content [(:text "Is mapcar a symbol?")]) (:role "assistant" :content [(:toolUse (:toolUseId "mXJojZBa789q7ECEVMMFMmjX" :name "symbol_exists" :input (:symbol "mapcar")))]) (:role "user" :content [(:toolResult (:toolUseId "mXJojZBa789q7ECEVMMFMmjX" :status "success" :content [(:text "mapcar
+
+*Fake Heading Needing Unescape")]))]) (:role "assistant" :content [(:text "Yes, =mapcar= is a symbol in Emacs Lisp.")]) (:role "user" :content [(:text "Is cat-dawg a symbol?")]) (:role "assistant" :content [(:toolUse (:toolUseId "ZJSK6DLEDXwEWvYl6CaRirFy" :name "symbol_exists" :input (:symbol "cat-dawg")))]) (:role "user" :content [(:toolResult (:toolUseId "ZJSK6DLEDXwEWvYl6CaRirFy" :status "success" :content [(:text "cat-dawg
+
+*Fake Heading Needing Unescape")]))]) (:role "assistant" :content [(:text "No, =cat-dawg= is not a symbol in Emacs Lisp.")]) (:role "user" :content [(:text "That's all I guess.  Try not to kill us all.")]) (:role "assistant" :content [(:text "Understood. If you have more questions or need assistance, feel free to ask.")]))

--- a/gptel-create-prompt-test.el
+++ b/gptel-create-prompt-test.el
@@ -524,3 +524,13 @@ Some details")))))
          (gptel-org-ignore-elements nil)
          (gptel-prompt-filter-hook nil))
      (gptel--create-prompt (point-max)))))
+
+;;;; Bedrock
+(gptel-test-prompt-creation
+    "bedrock-tool-block-org" "examples/bedrock-prompt-tool-block-org.eld"
+  (with-gptel-chat-file
+   "examples/prompt-creation-tool-block.org" bedrock nil
+   (let ((gptel-org-branching-context nil)
+         (gptel-org-ignore-elements nil)
+         (gptel-prompt-filter-hook nil))
+     (gptel--create-prompt (point-max)))))


### PR DESCRIPTION
This adds a parsing test for the Bedrock backend's multi-turn tool use handling, as requested in karthink/gptel#1410.

The test exercises `gptel--parse-buffer` against the existing `prompt-creation-tool-block.org` fixture (two sequential tool calls) and verifies that the output is stable across changes. The correctness of the output against the Bedrock Converse API was validated by manual testing in karthink/gptel#1410.